### PR TITLE
Add GitHub Pages docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,15 @@ Replace `<TOKEN>` with the registration token from your repository settings.
 
 The backend code now follows basic `flake8` conventions for improved readability.
 The Docker build workflow now points to `ScoutOS/backend/Dockerfile`.
+
+## GitHub Pages
+
+The `docs/` directory contains the homepage used for GitHub Pages. To publish it:
+
+1. Open repository **Settings** > **Pages**.
+2. Select the `live_update` branch and `/docs` as the folder.
+3. Enable **Enforce HTTPS** for secure connections.
+4. Keep the repository private so only authorized collaborators can view the site.
+5. Protect the `live_update` branch to restrict updates.
+
+Once saved, GitHub Pages will serve `docs/index.md` from that branch.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Welcome to ScoutOS
+
+This page is hosted with **GitHub Pages**.
+
+ScoutOS is a monitoring and deployment stack built with FastAPI and Docker.


### PR DESCRIPTION
## Summary
- add docs/index.md as homepage content
- document how to enable GitHub Pages securely
- update docs to use branch `live_update`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686f02611abc8322bc559333e42df906