### PR TITLE
Fix CodeQL workflow syntax

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,15 +1,4 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL Advanced"
+name: "CodeQL Analysis"
 
 on:
   push:
@@ -22,186 +11,28 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
       actions: read
       contents: read
-
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
-        include:
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+        language: [ 'python' ]
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
-
-                    - name: Close Stale Issues
-  uses: actions/stale@v9.1.0
-  with:
-    # Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`.
-    repo-token: # optional, default is ${{ github.token }}
-    # The message to post on the issue when tagging it. If none provided, will not mark issues stale.
-    stale-issue-message: # optional
-    # The message to post on the pull request when tagging it. If none provided, will not mark pull requests stale.
-    stale-pr-message: # optional
-    # The message to post on the issue when closing it. If none provided, will not comment when closing an issue.
-    close-issue-message: # optional
-    # The message to post on the pull request when closing it. If none provided, will not comment when closing a pull requests.
-    close-pr-message: # optional
-    # The number of days old an issue or a pull request can be before marking it stale. Set to -1 to never mark issues or pull requests as stale automatically.
-    days-before-stale: # optional, default is 60
-    # The number of days old an issue can be before marking it stale. Set to -1 to never mark issues as stale automatically. Override "days-before-stale" option regarding only the issues.
-    days-before-issue-stale: # optional
-    # The number of days old a pull request can be before marking it stale. Set to -1 to never mark pull requests as stale automatically. Override "days-before-stale" option regarding only the pull requests.
-    days-before-pr-stale: # optional
-    # The number of days to wait to close an issue or a pull request after it being marked stale. Set to -1 to never close stale issues or pull requests.
-    days-before-close: # optional, default is 7
-    # The number of days to wait to close an issue after it being marked stale. Set to -1 to never close stale issues. Override "days-before-close" option regarding only the issues.
-    days-before-issue-close: # optional
-    # The number of days to wait to close a pull request after it being marked stale. Set to -1 to never close stale pull requests. Override "days-before-close" option regarding only the pull requests.
-    days-before-pr-close: # optional
-    # The label to apply when an issue is stale.
-    stale-issue-label: # optional, default is Stale
-    # The label to apply when an issue is closed.
-    close-issue-label: # optional
-    # The labels that mean an issue is exempt from being marked stale. Separate multiple labels with commas (eg. "label1,label2").
-    exempt-issue-labels: # optional, default is 
-    # The reason to use when closing an issue.
-    close-issue-reason: # optional, default is not_planned
-    # The label to apply when a pull request is stale.
-    stale-pr-label: # optional, default is Stale
-    # The label to apply when a pull request is closed.
-    close-pr-label: # optional
-    # The labels that mean a pull request is exempt from being marked as stale. Separate multiple labels with commas (eg. "label1,label2").
-    exempt-pr-labels: # optional, default is 
-    # The milestones that mean an issue or a pull request is exempt from being marked as stale. Separate multiple milestones with commas (eg. "milestone1,milestone2").
-    exempt-milestones: # optional, default is 
-    # The milestones that mean an issue is exempt from being marked as stale. Separate multiple milestones with commas (eg. "milestone1,milestone2"). Override "exempt-milestones" option regarding only the issues.
-    exempt-issue-milestones: # optional, default is 
-    # The milestones that mean a pull request is exempt from being marked as stale. Separate multiple milestones with commas (eg. "milestone1,milestone2"). Override "exempt-milestones" option regarding only the pull requests.
-    exempt-pr-milestones: # optional, default is 
-    # Exempt all issues and pull requests with milestones from being marked as stale. Default to false.
-    exempt-all-milestones: # optional, default is false
-    # Exempt all issues with milestones from being marked as stale. Override "exempt-all-milestones" option regarding only the issues.
-    exempt-all-issue-milestones: # optional, default is 
-    # Exempt all pull requests with milestones from being marked as stale. Override "exempt-all-milestones" option regarding only the pull requests.
-    exempt-all-pr-milestones: # optional, default is 
-    # Only issues or pull requests with all of these labels are checked if stale. Defaults to `` (disabled) and can be a comma-separated list of labels.
-    only-labels: # optional, default is 
-    # Only issues or pull requests with at least one of these labels are checked if stale. Defaults to `` (disabled) and can be a comma-separated list of labels.
-    any-of-labels: # optional, default is 
-    # Only issues with at least one of these labels are checked if stale. Defaults to `` (disabled) and can be a comma-separated list of labels. Override "any-of-labels" option regarding only the issues.
-    any-of-issue-labels: # optional, default is 
-    # Only pull requests with at least one of these labels are checked if stale. Defaults to `` (disabled) and can be a comma-separated list of labels. Override "any-of-labels" option regarding only the pull requests.
-    any-of-pr-labels: # optional, default is 
-    # Only issues with all of these labels are checked if stale. Defaults to `[]` (disabled) and can be a comma-separated list of labels. Override "only-labels" option regarding only the issues.
-    only-issue-labels: # optional, default is 
-    # Only pull requests with all of these labels are checked if stale. Defaults to `[]` (disabled) and can be a comma-separated list of labels. Override "only-labels" option regarding only the pull requests.
-    only-pr-labels: # optional, default is 
-    # The maximum number of operations per run, used to control rate limiting (GitHub API CRUD related).
-    operations-per-run: # optional, default is 30
-    # Remove stale labels from issues and pull requests when they are updated or commented on.
-    remove-stale-when-updated: # optional, default is true
-    # Remove stale labels from issues when they are updated or commented on. Override "remove-stale-when-updated" option regarding only the issues.
-    remove-issue-stale-when-updated: # optional, default is 
-    # Remove stale labels from pull requests when they are updated or commented on. Override "remove-stale-when-updated" option regarding only the pull requests.
-    remove-pr-stale-when-updated: # optional, default is 
-    # Run the processor in debug mode without actually performing any operations on live issues.
-    debug-only: # optional, default is false
-    # The order to get issues or pull requests. Defaults to false, which is descending.
-    ascending: # optional, default is false
-    # Delete the git branch after closing a stale pull request.
-    delete-branch: # optional, default is false
-    # The date used to skip the stale action on issue/pull request created before it (ISO 8601 or RFC 2822).
-    start-date: # optional, default is 
-    # The assignees which exempt an issue or a pull request from being marked as stale. Separate multiple assignees with commas (eg. "user1,user2").
-    exempt-assignees: # optional, default is 
-    # The assignees which exempt an issue from being marked as stale. Separate multiple assignees with commas (eg. "user1,user2"). Override "exempt-assignees" option regarding only the issues.
-    exempt-issue-assignees: # optional, default is 
-    # The assignees which exempt a pull request from being marked as stale. Separate multiple assignees with commas (eg. "user1,user2"). Override "exempt-assignees" option regarding only the pull requests.
-    exempt-pr-assignees: # optional, default is 
-    # Exempt all issues and pull requests with assignees from being marked as stale. Default to false.
-    exempt-all-assignees: # optional, default is false
-    # Exempt all issues with assignees from being marked as stale. Override "exempt-all-assignees" option regarding only the issues.
-    exempt-all-issue-assignees: # optional, default is 
-    # Exempt all pull requests with assignees from being marked as stale. Override "exempt-all-assignees" option regarding only the pull requests.
-    exempt-all-pr-assignees: # optional, default is 
-    # Exempt draft pull requests from being marked as stale. Default to false.
-    exempt-draft-pr: # optional, default is false
-    # Display some statistics at the end regarding the stale workflow (only when the logs are enabled).
-    enable-statistics: # optional, default is true
-    # A comma delimited list of labels to add when an issue or pull request becomes unstale.
-    labels-to-add-when-unstale: # optional, default is 
-    # A comma delimited list of labels to remove when an issue or pull request becomes stale.
-    labels-to-remove-when-stale: # optional, default is 
-    # A comma delimited list of labels to remove when an issue or pull request becomes unstale.
-    labels-to-remove-when-unstale: # optional, default is 
-    # Any update (update/comment) can reset the stale idle time on the issues and pull requests.
-    ignore-updates: # optional, default is false
-    # Any update (update/comment) can reset the stale idle time on the issues. Override "ignore-updates" option regarding only the issues.
-    ignore-issue-updates: # optional, default is 
-    # Any update (update/comment) can reset the stale idle time on the pull requests. Override "ignore-updates" option regarding only the pull requests.
-    ignore-pr-updates: # optional, default is 
-    # Only the issues or the pull requests with an assignee will be marked as stale automatically.
-    include-only-assigned: # optional, default is false
-          
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -26,3 +26,16 @@ Replace `<TOKEN>` with the registration token from your repository settings.
 
 The backend code now follows basic `flake8` conventions for improved readability.
 The Docker build workflow now points to `ScoutOS/backend/Dockerfile`.
+
+## GitHub Pages
+
+The `docs/` directory contains the homepage used for GitHub Pages. To publish it:
+
+1. Create a branch named `live_update` from your default branch if it doesn't exist.
+2. Open repository **Settings** > **Pages**.
+3. Select the `live_update` branch and `/docs` as the folder.
+4. Enable **Enforce HTTPS** for secure connections.
+5. Keep the repository private so only authorized collaborators can view the site.
+6. Protect the `live_update` branch to restrict updates.
+
+Once saved, GitHub Pages will serve `docs/index.md` from that branch.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Welcome to ScoutOS
+
+This page is hosted with **GitHub Pages**.
+
+ScoutOS is a monitoring and deployment stack built with FastAPI and Docker.


### PR DESCRIPTION
## Summary
- replace malformed `codeql.yml` with a valid workflow

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686f02611abc8322bc559333e42df906