### PR TITLE
Add simple dashboard interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ To provision a new server, run the `setup_scoutos_server.sh` script on your Ubun
 
 The `ScoutOS` folder now contains a FastAPI backend with a Docker-based deployment setup. Run `docker-compose up` inside that directory to start the development stack.
 
+The stack now also includes a lightweight dashboard served from the `frontend` container. Visit `http://localhost:3000` after running Docker Compose to view active user and storage metrics.
+
 For information on how to report security issues, see [SECURITY.md](SECURITY.md).
 
 ## Setting up a self-hosted GitHub Actions runner

--- a/ScoutOS/backend/app/endpoints.py
+++ b/ScoutOS/backend/app/endpoints.py
@@ -22,6 +22,19 @@ async def handshake(user_id: str = Depends(get_current_user)):
     return {"message": f"Handshake successful for user {user_id}"}
 
 
+@router.get("/dashboard")
+async def dashboard():
+    from .metrics_utils import get_storage_usage, get_active_users_count
+
+    active_users = await get_active_users_count()
+    used_bytes, total_bytes = await get_storage_usage("/")
+    return {
+        "active_users": active_users,
+        "storage_used_bytes": used_bytes,
+        "storage_total_bytes": total_bytes,
+    }
+
+
 @router.post("/upload-document")
 async def upload_document(
     file: UploadFile = File(...),

--- a/ScoutOS/backend/app/metrics_utils.py
+++ b/ScoutOS/backend/app/metrics_utils.py
@@ -1,0 +1,13 @@
+import os
+from .session_manager import get_active_users_count as session_active_users_count
+
+
+async def get_storage_usage(path: str):
+    stat = os.statvfs(path)
+    total_bytes = stat.f_frsize * stat.f_blocks
+    used_bytes = total_bytes - (stat.f_frsize * stat.f_bfree)
+    return used_bytes, total_bytes
+
+
+async def get_active_users_count():
+    return await session_active_users_count()

--- a/ScoutOS/frontend/Dockerfile
+++ b/ScoutOS/frontend/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html

--- a/ScoutOS/frontend/index.html
+++ b/ScoutOS/frontend/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>ScoutOS Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    .metric { margin-bottom: 1em; }
+  </style>
+</head>
+<body>
+  <h1>ScoutOS Dashboard</h1>
+  <div id="metrics">Loading...</div>
+  <script>
+    async function loadMetrics() {
+      try {
+        const res = await fetch('/api/dashboard');
+        if (!res.ok) throw new Error('Request failed');
+        const data = await res.json();
+        document.getElementById('metrics').innerHTML = `
+          <div class="metric">Active Users: ${data.active_users}</div>
+          <div class="metric">Storage Used: ${data.storage_used_bytes} / ${data.storage_total_bytes} bytes</div>
+        `;
+      } catch (err) {
+        document.getElementById('metrics').textContent = 'Failed to load metrics';
+      }
+    }
+    loadMetrics();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose a `/dashboard` API endpoint
- implement helper functions to report disk and session metrics
- add a lightweight frontend served via nginx
- document running the new dashboard

## Testing
- `python -m py_compile ScoutOS/backend/app/metrics_utils.py ScoutOS/backend/app/endpoints.py`
- `shellcheck setup_scoutos_server.sh ScoutOS/scripts/auto_deploy_scoutos_full.sh | head`

------
https://chatgpt.com/codex/tasks/task_e_686f12ff70208322ad14a7359cdf3c1b