### PR TITLE
Add React dashboard and realtime metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To provision a new server, run the `setup_scoutos_server.sh` script on your Ubun
 
 The `ScoutOS` folder now contains a FastAPI backend with a Docker-based deployment setup. Run `docker-compose up` inside that directory to start the development stack.
 
-The stack now also includes a lightweight dashboard served from the `frontend` container. Visit `http://localhost:3000` after running Docker Compose to view active user and storage metrics.
+The stack now includes a React dashboard served from the `frontend` container. Visit `http://localhost:3000` after running Docker Compose to see live metrics update over WebSockets.
 
 For information on how to report security issues, see [SECURITY.md](SECURITY.md).
 

--- a/ScoutOS/backend/app/background_tasks.py
+++ b/ScoutOS/backend/app/background_tasks.py
@@ -1,6 +1,8 @@
 import asyncio
-from metrics_utils import get_storage_usage, get_active_users_count
-from metrics import ACTIVE_USERS_TOTAL, STORAGE_USED_BYTES, STORAGE_TOTAL_BYTES
+import json
+from .metrics_utils import get_storage_usage, get_active_users_count
+from .metrics import ACTIVE_USERS_TOTAL, STORAGE_USED_BYTES, STORAGE_TOTAL_BYTES
+from .websocket_manager import manager
 
 
 async def update_metrics_periodically():
@@ -11,6 +13,13 @@ async def update_metrics_periodically():
         used_bytes, total_bytes = await get_storage_usage("/")
         STORAGE_USED_BYTES.set(used_bytes)
         STORAGE_TOTAL_BYTES.set(total_bytes)
+
+        metrics_data = {
+            "active_users": active_users,
+            "storage_used_bytes": used_bytes,
+            "storage_total_bytes": total_bytes,
+        }
+        await manager.broadcast(json.dumps({"type": "metrics", "data": metrics_data}))
 
         await asyncio.sleep(60)
 

--- a/ScoutOS/frontend/index.html
+++ b/ScoutOS/frontend/index.html
@@ -1,31 +1,67 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8">
+  <meta charset="utf-8" />
   <title>ScoutOS Dashboard</title>
   <style>
     body { font-family: Arial, sans-serif; margin: 2em; }
     .metric { margin-bottom: 1em; }
+    .message { border-bottom: 1px solid #ccc; padding: 4px 0; }
   </style>
 </head>
 <body>
-  <h1>ScoutOS Dashboard</h1>
-  <div id="metrics">Loading...</div>
-  <script>
-    async function loadMetrics() {
-      try {
-        const res = await fetch('/api/dashboard');
-        if (!res.ok) throw new Error('Request failed');
-        const data = await res.json();
-        document.getElementById('metrics').innerHTML = `
-          <div class="metric">Active Users: ${data.active_users}</div>
-          <div class="metric">Storage Used: ${data.storage_used_bytes} / ${data.storage_total_bytes} bytes</div>
-        `;
-      } catch (err) {
-        document.getElementById('metrics').textContent = 'Failed to load metrics';
-      }
+  <div id="root">Loading...</div>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script type="text/babel">
+    function App() {
+      const [metrics, setMetrics] = React.useState(null);
+      const [messages, setMessages] = React.useState([]);
+
+      React.useEffect(() => {
+        async function load() {
+          try {
+            const res = await fetch('/api/dashboard');
+            const data = await res.json();
+            setMetrics(data);
+          } catch (err) {
+            console.error(err);
+          }
+        }
+        load();
+        const ws = new WebSocket(`ws://${window.location.host}/ws/guest`);
+        ws.onmessage = event => {
+          setMessages(msgs => [...msgs, event.data]);
+        };
+        return () => ws.close();
+      }, []);
+
+      return (
+        <div>
+          <h1>ScoutOS Dashboard</h1>
+          {metrics ? (
+            <div>
+              <div className="metric">Active Users: {metrics.active_users}</div>
+              <div className="metric">
+                Storage Used: {metrics.storage_used_bytes} / {metrics.storage_total_bytes} bytes
+              </div>
+            </div>
+          ) : (
+            <div>Loading metrics...</div>
+          )}
+          <h2>Messages</h2>
+          <div id="messages">
+            {messages.map((m, i) => (
+              <div key={i} className="message">{m}</div>
+            ))}
+          </div>
+        </div>
+      );
     }
-    loadMetrics();
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement React single page dashboard
- broadcast metrics via WebSocket
- update documentation for React and realtime updates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f24560dc88322acdcfa00a0a86376