### PR TITLE
Fix flake8 line length warnings

### DIFF
--- a/ScoutOS/backend/app/background_tasks.py
+++ b/ScoutOS/backend/app/background_tasks.py
@@ -1,7 +1,11 @@
 import asyncio
 import json
 from .metrics_utils import get_storage_usage, get_active_users_count
-from .metrics import ACTIVE_USERS_TOTAL, STORAGE_USED_BYTES, STORAGE_TOTAL_BYTES
+from .metrics import (
+    ACTIVE_USERS_TOTAL,
+    STORAGE_USED_BYTES,
+    STORAGE_TOTAL_BYTES,
+)
 from .websocket_manager import manager
 
 
@@ -19,7 +23,9 @@ async def update_metrics_periodically():
             "storage_used_bytes": used_bytes,
             "storage_total_bytes": total_bytes,
         }
-        await manager.broadcast(json.dumps({"type": "metrics", "data": metrics_data}))
+        await manager.broadcast(
+            json.dumps({"type": "metrics", "data": metrics_data})
+        )
 
         await asyncio.sleep(60)
 

--- a/ScoutOS/backend/app/metrics_utils.py
+++ b/ScoutOS/backend/app/metrics_utils.py
@@ -1,5 +1,7 @@
 import os
-from .session_manager import get_active_users_count as session_active_users_count
+from .session_manager import (
+    get_active_users_count as session_active_users_count,
+)
 
 
 async def get_storage_usage(path: str):


### PR DESCRIPTION
## Summary
- wrap long imports in `background_tasks.py`
- split broadcast call over multiple lines
- wrap long import in `metrics_utils.py`

## Testing
- `shellcheck setup_scoutos_server.sh ScoutOS/scripts/auto_deploy_scoutos_full.sh`
- `flake8 ScoutOS/backend/app`
- `python -m py_compile $(find ScoutOS/backend/app -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686f278031f48322a587c7bb1c7300ab