### PR TITLE
Update security contact note

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The `ScoutOS` folder now contains a FastAPI backend with a Docker-based deployme
 
 The stack now includes a React dashboard served from the `frontend` container. Visit `http://localhost:3000` after running Docker Compose to see live metrics update over WebSockets.
 
-For information on how to report security issues, see [SECURITY.md](SECURITY.md).
+For details on how to report vulnerabilities, see [SECURITY.md](SECURITY.md). Our workflow is to accept reports via email or GitHub's security advisories. The listed address is `security@example.com` as a placeholder—replace it with the real project contact.
 
 ## Setting up a self-hosted GitHub Actions runner
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ We currently support the latest release of ScoutOS. Older versions may not recei
 
 ## Reporting a Vulnerability
 
-If you discover a security issue in ScoutOS, please report it privately by emailing [security@example.com](mailto:security@example.com).
+If you discover a security issue in ScoutOS, please report it privately by emailing [security@example.com](mailto:security@example.com) or by opening a private GitHub security advisory. `security@example.com` is an example address—replace it with your actual security contact.
 We will respond as quickly as possible and coordinate a fix.
 
 Please do not publicly disclose security issues until we have had a chance to address them.


### PR DESCRIPTION
## Summary
- clarify placeholder contact for security reports
- mention GitHub advisory option

## Testing
- `shellcheck --version 2>&1 | head -n 1`
- `shellcheck setup_scoutos_server.sh`
- `shellcheck ScoutOS/scripts/auto_deploy_scoutos_full.sh`


------
https://chatgpt.com/codex/tasks/task_e_686f29c0ca208322b4510b3ab7c76f7b