### PR TITLE
Add AI chat frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Before running the server setup script, open `setup_scoutos_server.sh` and adjus
 The `ScoutOS` folder now contains a FastAPI backend with a Docker-based deployment setup. Run `docker-compose up` inside that directory to start the development stack.
 
 The stack now includes a React dashboard served from the `frontend` container. Visit `http://localhost:3000` after running Docker Compose to see live metrics update over WebSockets.
+You can also experiment with the AI chat interface at `/chat.html` which connects to the backend AI API.
 
 For details on how to report vulnerabilities, see [SECURITY.md](SECURITY.md). Our workflow is to accept reports via email or GitHub's security advisories. The listed address is `security@example.com` as a placeholder—replace it with the real project contact.
 

--- a/ScoutOS/frontend/chat.html
+++ b/ScoutOS/frontend/chat.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>ScoutOS Chat</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    #messages { border: 1px solid #ccc; padding: 1em; height: 300px; overflow-y: auto; }
+    .msg { margin-bottom: 0.5em; }
+    .user { font-weight: bold; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script type="text/babel">
+    function ChatApp() {
+      const [messages, setMessages] = React.useState([]);
+      const [input, setInput] = React.useState('');
+
+      async function sendMessage() {
+        if (!input) return;
+        const userMsg = { type: 'user', text: input };
+        setMessages(msgs => [...msgs, userMsg]);
+        setInput('');
+        try {
+          const res = await fetch('/api/ai-chat', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: input }),
+          });
+          const data = await res.json();
+          const botMsg = { type: 'bot', text: data.reply };
+          setMessages(msgs => [...msgs, botMsg]);
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      return (
+        <div>
+          <h1>AI Chat</h1>
+          <div id="messages">
+            {messages.map((m, i) => (
+              <div key={i} className="msg">
+                <span className={m.type}>{m.type === 'user' ? 'You:' : 'AI:'}</span>
+                <span dangerouslySetInnerHTML={{ __html: ' ' + m.text }} />
+              </div>
+            ))}
+          </div>
+          <textarea
+            rows="3"
+            style={{ width: '100%' }}
+            value={input}
+            onChange={e => setInput(e.target.value)}
+          />
+          <button onClick={sendMessage}>Send</button>
+        </div>
+      );
+    }
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<ChatApp />);
+  </script>
+</body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@ This page is hosted with **GitHub Pages**.
 ScoutOS provides a lightweight monitoring and deployment platform. The stack
 combines a **FastAPI** backend with a **React** dashboard and is bundled using
 **Docker Compose** for easy setup.
+It now ships with a basic AI chat page for testing backend integrations.
 
 For step‑by‑step installation and server instructions, see the
 [project README](../README.md).


### PR DESCRIPTION
## Summary
- add basic React AI chat page under `frontend`
- document how to access it in README
- mention chat feature in docs home

## Testing
- `shellcheck setup_scoutos_server.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f38ed2ce883229b36ee8584e828e4