### PR TITLE
Fix dependabot codeql config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language: [ 'python', 'actions' ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Replace `<TOKEN>` with the registration token from your repository settings.
 The backend code now follows basic `flake8` conventions for improved readability.
 The Docker build workflow now points to `ScoutOS/backend/Dockerfile`.
 Dependabot now monitors dependencies in `ScoutOS/backend` and `ScoutOS/frontend`.
+Our CodeQL workflow scans both the Python backend and GitHub Actions workflows to catch issues early.
 
 ## GitHub Pages
 


### PR DESCRIPTION
## Summary
- expand CodeQL analysis to include GitHub Actions
- document CodeQL scanning in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f447c708483228ba2d755d764c2a3