### PR TITLE
Document secret key requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ You can also experiment with the AI chat interface at `/chat.html` which connect
 
 The backend now exposes an AI API at `/api/ai/prompt`. Each request persists the prompt and generated response in a local SQLite database so the agent can recall prior interactions.
 
+## Backend configuration
+
+Set a strong `SECRET_KEY` environment variable before starting the backend. If this variable isn't defined, the app defaults to a testing key which should not be used in production.
+
 For details on how to report vulnerabilities, see [SECURITY.md](SECURITY.md). Our workflow is to accept reports via email or GitHub's security advisories. The listed address is `security@example.com` as a placeholder—replace it with the real project contact.
 
 ## Setting up a self-hosted GitHub Actions runner

--- a/ScoutOS/backend/app/auth.py
+++ b/ScoutOS/backend/app/auth.py
@@ -8,6 +8,7 @@ oauth2_scheme = OAuth2AuthorizationCodeBearer(
     tokenUrl=os.getenv("OAUTH_TOKEN_URL", ""),
 )
 
+# Default key is for testing only. Set SECRET_KEY in the environment for production.
 SECRET_KEY = os.getenv("SECRET_KEY", "CHANGE_ME")
 ALGORITHM = "HS256"
 


### PR DESCRIPTION
## Summary
- document the `SECRET_KEY` environment variable requirement in the README
- clarify that the default key in `auth.py` is meant for testing only

## Testing
- `flake8 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f496ab04083228cb7ba1ab35e0e0e