### PR TITLE
Fix chat API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Before running the server setup script, open `setup_scoutos_server.sh` and adjus
 The `ScoutOS` folder now contains a FastAPI backend with a Docker-based deployment setup. Run `docker-compose up` inside that directory to start the development stack.
 
 The stack now includes a React dashboard served from the `frontend` container. Visit `http://localhost:3000` after running Docker Compose to see live metrics update over WebSockets.
-You can also experiment with the AI chat interface at `/chat.html` which connects to the backend AI API.
+You can also experiment with the AI chat interface at `/chat.html` which connects to the backend AI API. The chat page now posts prompts to `/api/ai/prompt`.
 
 The backend now exposes an AI API at `/api/ai/prompt`. Each request persists the prompt and generated response in a local SQLite database so the agent can recall prior interactions.
 

--- a/ScoutOS/frontend/chat.html
+++ b/ScoutOS/frontend/chat.html
@@ -26,7 +26,7 @@
         setMessages(msgs => [...msgs, userMsg]);
         setInput('');
         try {
-          const res = await fetch('/api/ai-chat', {
+          const res = await fetch('/api/ai/prompt', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ message: input }),


### PR DESCRIPTION
## Summary
- update chat.html to call `/api/ai/prompt`
- document new endpoint usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f4969acd48322b0cbdf18da86662d