### PR TITLE
Fix chat request payload and cleanup disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Before running the server setup script, open `setup_scoutos_server.sh` and adjus
 The `ScoutOS` folder now contains a FastAPI backend with a Docker-based deployment setup. Run `docker-compose up` inside that directory to start the development stack.
 
 The stack now includes a React dashboard served from the `frontend` container. Visit `http://localhost:3000` after running Docker Compose to see live metrics update over WebSockets.
-You can also experiment with the AI chat interface at `/chat.html` which connects to the backend AI API. The chat page now posts prompts to `/api/ai/prompt`.
+You can also experiment with the AI chat interface at `/chat.html` which connects to the backend AI API. The chat page sends JSON `{"prompt": "text"}` to `/api/ai/prompt` and displays the `response` field from the server.
 
 The backend now exposes an AI API at `/api/ai/prompt`. Each request persists the prompt and generated response in a local SQLite database so the agent can recall prior interactions.
 

--- a/ScoutOS/backend/app/websocket_manager.py
+++ b/ScoutOS/backend/app/websocket_manager.py
@@ -11,7 +11,13 @@ class ConnectionManager:
         self.active_connections.setdefault(user_id, []).append(websocket)
 
     def disconnect(self, user_id: str, websocket: WebSocket):
-        self.active_connections.get(user_id, []).remove(websocket)
+        connections = self.active_connections.get(user_id, [])
+        try:
+            connections.remove(websocket)
+            if not connections:
+                self.active_connections.pop(user_id, None)
+        except ValueError:
+            pass
 
     async def send_personal_message(self, message: str, user_id: str):
         connections = self.active_connections.get(user_id, [])

--- a/ScoutOS/frontend/chat.html
+++ b/ScoutOS/frontend/chat.html
@@ -29,10 +29,10 @@
           const res = await fetch('/api/ai/prompt', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ message: input }),
+            body: JSON.stringify({ prompt: input }),
           });
           const data = await res.json();
-          const botMsg = { type: 'bot', text: data.reply };
+          const botMsg = { type: 'bot', text: data.response };
           setMessages(msgs => [...msgs, botMsg]);
         } catch (err) {
           console.error(err);


### PR DESCRIPTION
## Summary
- fix chat.html to send correct JSON keys
- document AI prompt payload in README
- handle websocket disconnect errors gracefully

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `shellcheck setup_scoutos_server.sh ScoutOS/scripts/setup_scoutos_server.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f4e20c8708322b1e38b62a08f52fe